### PR TITLE
Version 0.5.1

### DIFF
--- a/app/checker/mono.py
+++ b/app/checker/mono.py
@@ -84,9 +84,6 @@ class Checker:
             self.queen = True
 
     def update(self):
-        if self.can_promote:
-            self.promote()
-
         updated_move_list = behavior.get_move_list(checker_object=self)
         if updated_move_list is not None:
             self.__move_list = updated_move_list[0]         # Move list

--- a/app/checker/spawn.py
+++ b/app/checker/spawn.py
@@ -1,12 +1,4 @@
-import app.board.test as test
 import app.checker.mono as mono
-
-
-def __checker_empty():
-    new_checker = mono.Checker(init_position=[],
-                               init_color='',
-                               init_type_queen=False)
-    return new_checker
 
 
 def __checker_predefined(spawn_position: list, spawn_color: str, spawn_queen: bool = False):
@@ -25,10 +17,7 @@ def __checker_undefined(spawn_position: list):
 
 
 def checker(spawn_position: list, spawn_color: str, spawn_queen: bool = False):
-    if test.position_can_spawn_checker(spawn_position):
-        if spawn_color in ('White', 'Black'):
-            return __checker_predefined(spawn_position, spawn_color, spawn_queen)
-        else:
-            return __checker_undefined(spawn_position)
+    if spawn_color in ('White', 'Black'):
+        return __checker_predefined(spawn_position, spawn_color, spawn_queen)
     else:
-        return __checker_empty()
+        return __checker_undefined(spawn_position)


### PR DESCRIPTION
1. **Refractored** checker/spawn and checker/mono:
    - Checker can no longer self-promote;
    - Checker can no longer spawn 'empty' checker object.

2. Added dev create checker on click function. With developer mode enabled, **right mouse button click** creates, rotates color, promotes and removes checker object on/from board surface.